### PR TITLE
add basic svg support

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,6 +64,7 @@ export default async function htmlToSvg(mainDiv, config = htmlToSvgConfig) {
   var defs = document.createElementNS("http://www.w3.org/2000/svg", "defs");
   svg.setAttribute("xmlns", "http://www.w3.org/2000/svg");
   svg.setAttribute("xmlns:xlink", "http://www.w3.org/1999/xlink");
+  // add namespaces to handle group properties well
   svg.setAttribute("xmlns:inkscape", "http://www.inkscape.org/namespaces/inkscape");
   svg.setAttribute("xmlns:sodipodi", "http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd");
   svg.setAttribute("xmlns:svg", "http://www.w3.org/2000/svg");


### PR DESCRIPTION
i needed to export html containing some paragraphs and a svg, so i added a new handler for SVG elements.
if a svg is found in the html, it will be transformed into a svg group and moved at the right position.

most elegant solution would have been to nest the found svg. this works well in browsers and inkscape, but are not (yet) fully compatible with adobe illustrator. they do not maintain the position when the generated file is opened.

also added the viewBox attribute so the generated svg becomes responsive.